### PR TITLE
Remove unsupported option

### DIFF
--- a/ievms.sh
+++ b/ievms.sh
@@ -157,7 +157,7 @@ build_ievm() {
         VBoxManage modifyvm "${vm}" --memory 256 --vram 32
         VBoxManage storagectl "${vm}" --name "IDE Controller" --add ide --controller PIIX4 --bootable on
         VBoxManage storagectl "${vm}" --name "Floppy Controller" --add floppy
-        VBoxManage storageattach "${vm}" --storagectl "IDE Controller" --port 0 --device 0 --type hdd --medium "${vhd_path}/${vhd}" --setuuid ""
+        VBoxManage storageattach "${vm}" --storagectl "IDE Controller" --port 0 --device 0 --type hdd --medium "${vhd_path}/${vhd}"
         VBoxManage storageattach "${vm}" --storagectl "IDE Controller" --port 0 --device 1 --type dvddrive --medium "${ga_iso}"
         VBoxManage storageattach "${vm}" --storagectl "Floppy Controller" --port 0 --device 0 --type fdd --medium emptydrive
         VBoxManage snapshot "${vm}" take clean --description "The initial VM state"


### PR DESCRIPTION
the VBoxManage "storageattach" command does not accept the --setuuid option and causes the script to bomb.  This was with VBoxManage version 4.0.0r69151.

Not sure the implications of removing it...but everything works ok here after doing so.

VirtualBox ver. 4.0.0 r69151
