### PR TITLE
Patch to make the script work on gentoo (and probably some other distros too)

### DIFF
--- a/ievms.sh
+++ b/ievms.sh
@@ -34,7 +34,7 @@ check_virtualbox() {
     log "Checking for Oracle VM VirtualBox Extension Pack"
     if ! VBoxManage list extpacks | grep "Oracle VM VirtualBox Extension Pack"
     then
-        version=`VBoxManage -v`
+        version=`VBoxManage -v | cut -f 1 -d -`
         ext_version="${version/r/-}"
         short_version="${version/r*/}"
         url="http://download.virtualbox.org/virtualbox/${short_version}/Oracle_VM_VirtualBox_Extension_Pack-${ext_version}.vbox-extpack"


### PR DESCRIPTION
I had to modify the version string, because `VBoxManage -v` returns "4.1.8-Gentoo_r75467" on my system.

The script would therefore try to download
http://download.virtualbox.org/virtualbox/4.1.8-Gentoo_/Oracle_VM_VirtualBox_Extension_Pack-4.1.8-Gentoo_-75467.vbox-extpack
which is obviously wrong.
