### PR TITLE
Add support for extra versions

### DIFF
--- a/ievms.sh
+++ b/ievms.sh
@@ -37,8 +37,8 @@ check_virtualbox() {
     if ! VBoxManage list extpacks | grep "Oracle VM VirtualBox Extension Pack"
     then
         version=`VBoxManage -v`
-        ext_version="${version/r/-}"
-        short_version="${version/r*/}"
+        ext_version="${version/?(_*)r/-}"
+        short_version="${version/?(_*)r*/}"
         url="http://download.virtualbox.org/virtualbox/${short_version}/Oracle_VM_VirtualBox_Extension_Pack-${ext_version}.vbox-extpack"
         archive="Oracle_VM_VirtualBox_Extension_Pack-${ext_version}.vbox-extpack"
 


### PR DESCRIPTION
Different versions of VBoxManage give the following
output for VBoxManage -v
 x.y.zz_CODErabcde

where CODE may be Debian, OSE, Ubuntu, to name a few

Currently the parser expects
 x.y.zzrabcde
otherwise the download fails

This patch changes the parser to detect the optional
extra version and parse correctly
