### PR TITLE
Add check for VirtualBox Guest Additions

### DIFF
--- a/ievms.sh
+++ b/ievms.sh
@@ -34,7 +34,11 @@ check_virtualbox() {
     hash VBoxManage 2>&- || fail "VirtualBox is not installed! (http://virtualbox.org)"
 
     log "Checking for VirtualBox Guest Additions"
-    [ -e /usr/share/virtualbox/VBoxGuestAdditions.iso ] || fail "VirtualBox Guest Additions are not installed! (http://virtualbox.org)"
+    case $kernel in
+        Darwin) ga_iso="/Applications/VirtualBox.app/Contents/MacOS/VBoxGuestAdditions.iso" ;;
+        Linux) ga_iso="/usr/share/virtualbox/VBoxGuestAdditions.iso" ;;
+    esac
+    [ -e "$ga_iso" ] || fail "VirtualBox Guest Additions are not installed! (http://virtualbox.org)"
 
     log "Checking for Oracle VM VirtualBox Extension Pack"
     if ! VBoxManage list extpacks | grep "Oracle VM VirtualBox Extension Pack"


### PR DESCRIPTION
Currently if not installed, the following error occurs:

 VBoxManage: error: Could not find file for the medium '/usr/share/virtualbox/VBoxGuestAdditions.iso' (VERR_FILE_NOT_FOUND)
 VBoxManage: error: Details: code VBOX_E_FILE_ERROR (0x80bb0004), component Medium, interface IMedium, callee nsISupports
 Context: "OpenMedium(Bstr(pszFilenameOrUuid).raw(), enmDevType, AccessMode_ReadWrite, fForceNewUuidOnOpen, pMedium.asOutParam())" at line 210 of file VBoxManageDisk.cpp
 VBoxManage: error: Invalid UUID or filename "/usr/share/virtualbox/VBoxGuestAdditions.iso"

When the command is re-run, the VM it failed on is skipped.

This patch adds a check for the guest additions
