### PR TITLE
Strip _OSE suffix from version reported by VManageBox -v

### DIFF
--- a/ievms.sh
+++ b/ievms.sh
@@ -36,7 +36,7 @@ check_virtualbox() {
     log "Checking for Oracle VM VirtualBox Extension Pack"
     if ! VBoxManage list extpacks | grep "Oracle VM VirtualBox Extension Pack"
     then
-        version=`VBoxManage -v`
+        version=`VBoxManage -v|sed s/_OSE//`
         ext_version="${version/r/-}"
         short_version="${version/r*/}"
         url="http://download.virtualbox.org/virtualbox/${short_version}/Oracle_VM_VirtualBox_Extension_Pack-${ext_version}.vbox-extpack"


### PR DESCRIPTION
On my arch linux box VManageBox -v reports this version:

```
4.1.20_OSEr80170
```

so it's necessary to strip the _OSE suffix in order to build the URL of the extension pack.
