### PR TITLE
Use pkgutil instead of xar to extract cabextract on Darwin

### DIFF
--- a/ievms.sh
+++ b/ievms.sh
@@ -121,8 +121,7 @@ download_cabextract() {
         fail "Failed to download ${url} to ${ievms_home}/${archive} using 'curl', error code ($?)"
     fi
 
-    mkdir -p "${ievms_home}/cabextract"
-    if ! xar -xf "${archive}" -C "${ievms_home}/cabextract"
+    if ! pkgutil --expand "${archive}" "${ievms_home}/cabextract"
     then
         fail "Failed to extract ${ievms_home}/${archive} to ${ievms_home}/cabextract," \
             "xar command returned error code $?"


### PR DESCRIPTION
xar was bailing out when chmoding file privileges after extraction of cabextract. 
The was with INSTALL_PATH set to an afp3 mount, freenas 8, couldn't figure out what the cause of the problem was but using pkgutil instead of xar solved this.
chmod used independently works fine.
