### PR TITLE
Added check for unloaded kernel module in version output

### DIFF
--- a/ievms.sh
+++ b/ievms.sh
@@ -40,6 +40,10 @@ check_version() {
     major_minor="${version%.*}"
     dl_page=`curl ${curl_opts} -L "http://download.virtualbox.org/virtualbox/" 2>/dev/null`
 
+    if [[ "$version" == *"kernel module is not loaded"* ]]; then
+        fail "$version"
+    fi
+
     for (( release="${major_minor_release#*.*.}"; release >= 0; release-- ))
     do
         major_minor_release="${major_minor}.${release}"


### PR DESCRIPTION
Fixes #107

When the kernel module is not loaded an error message is output when
running VBoxManage -v (though the exit code is still 0). This prevents
$major_minor_release from being assigned correctly. The script will exit
with the following error message:

bash: line 43: WARNING: unbound variable

The error message contains instructions on how to load/rebuild the
kernel module for the given platform, so we can just exit and output
that message verbatim. The following is an example of the message on
Fedora:

WARNING: The vboxdrv kernel module is not loaded. Either there is no module
         available for the current kernel (3.7.3-101.fc17.x86_64) or it failed to
         load. Please recompile the kernel module and install it by

```
       sudo /etc/init.d/vboxdrv setup

     You will not be able to start VMs until this problem is fixed.
```

4.1.24r82872
