### PR TITLE
If no unar on Linux, use 7z

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Requirements
 
 * VirtualBox (http://virtualbox.org), select 'command line utilities' during installation
 * Curl (Ubuntu: `sudo apt-get install curl`)
-* Linux Only: unar (Ubuntu: `sudo apt-get install unar`)
+* Linux Only: unar (Ubuntu: `sudo apt-get install unar`) OR 7zip (Ubuntu: `sudo apt-get install p7zip-full`)
 * Patience
 
 

--- a/ievms.sh
+++ b/ievms.sh
@@ -173,13 +173,13 @@ install_unar() {
     hash unar 2>&- || fail "Could not find unar in ${ievms_home}"
 }
 
-# Check for the `unar` command, downloading and installing it if not found.
-check_unar() {
+# Check for the `unar` command on Mac, downloading and installing it if not found, or 7z on Linux.
+check_unarchiver() {
     if [ "${kernel}" == "Darwin" ]
     then
         hash unar 2>&- || install_unar
     else
-        hash unar 2>&- || fail "Linux support requires unar (sudo apt-get install for Ubuntu/Debian)"
+        hash unar 2>&- || hash 7za 2>&- || fail "Linux support requires unar or 7za (sudo apt-get install for Ubuntu/Debian)"
     fi
 }
 
@@ -394,7 +394,22 @@ build_ievm() {
         download "OVA ZIP" "${url}" "${archive}" "${md5}"
 
         log "Extracting OVA from ${ievms_home}/${archive}"
-        unar "${archive}" || fail "Failed to extract ${archive} to ${ievms_home}/${ova}, unar command returned error code $?"
+        unarchiver_command=unar
+        if [ "${kernel}" == "Darwin" ]
+        then
+            unar "${archive}"
+        elif hash unar 2>&-
+        then
+            unar "${archive}"
+        else
+            unarchiver_command=7z
+            7za e "${archive}"
+        fi
+        if [ "$?" != "0" ]
+        then
+            fail "Failed to extract ${archive} to ${ievms_home}/${ova}," \
+                "${unarchiver_command} command returned error code $?"
+        fi
     fi
 
     log "Checking for existing ${vm} VM"
@@ -472,7 +487,7 @@ check_system
 create_home
 check_virtualbox
 check_ext_pack
-check_unar
+check_unarchiver
 
 # Install each requested virtual machine sequentially.
 all_versions="6 7 8 9 10 11"


### PR DESCRIPTION
On some distributions, like Fedora, `unar` is not readily available from a repository. However `7za`, which is generally available from the `p7zip` package (e.g. http://koji.fedoraproject.org/koji/packageinfo?packageID=2715) is available, and works fine to unzip the large VM files.

Modified the script to check for and use `7za` if `unar` is not available.
