### PR TITLE
Add support for IEVMS_MIRROR argument

### DIFF
--- a/ievms.sh
+++ b/ievms.sh
@@ -140,8 +140,9 @@ build_ievm() {
     archive=${archive:-$def_archive}
     unit=${unit:-"11"}
     ova=`basename "${archive/_/ - }" .zip`.ova
-    url="http://virtualization.modern.ie/vhd/IEKitV1_Final/VirtualBox/OSX/${archive}"
-    
+    mirror="http://virtualization.modern.ie/vhd/IEKitV1_Final/VirtualBox/OSX"
+    url="${IEVMS_MIRROR:-$mirror}/${archive}"
+
     log "Checking for existing OVA at ${ievms_home}/${ova}"
     if [[ ! -f "${ova}" ]]
     then


### PR DESCRIPTION
Allows you specify a mirror of virtulization.modern.ie. This was a desired for my usage where we use ievms to configure multiple machines.