### PR TITLE
Prefix envars in README.md with 'env'

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Specifying the install path
 
 To specify where the VMs are installed, use the `INSTALL_PATH` variable:
 
-    curl -s https://raw.github.com/xdissent/ievms/master/ievms.sh | INSTALL_PATH="/Path/to/.ievms" bash
+    curl -s https://raw.github.com/xdissent/ievms/master/ievms.sh | env INSTALL_PATH="/Path/to/.ievms" bash
 
 
 Passing additional options to curl
@@ -130,7 +130,7 @@ Passing additional options to curl
 The `curl` command is passed any options present in the `CURL_OPTS` 
 environment variable. For example, you can set a download speed limit:
 
-    curl -s https://raw.github.com/xdissent/ievms/master/ievms.sh | CURL_OPTS="--limit-rate 50k" bash
+    curl -s https://raw.github.com/xdissent/ievms/master/ievms.sh | env CURL_OPTS="--limit-rate 50k" bash
 
 
 Features
@@ -167,7 +167,7 @@ includes the updated browser version.
 **NOTE:** If you'd like to disable XP VM reuse for IE7 and IE8, set the 
 environment variable `REUSE_XP` to anything other than `yes`:
 
-    curl -s https://raw.github.com/xdissent/ievms/master/ievms.sh | REUSE_XP="no" bash
+    curl -s https://raw.github.com/xdissent/ievms/master/ievms.sh | env REUSE_XP="no" bash
 
 
 Control ISO


### PR DESCRIPTION
Without this the commands don't work in fish and probably some other shells.

Thanks,
