### PR TITLE
Check VM Existence from list of VMS

### DIFF
--- a/ievms.sh
+++ b/ievms.sh
@@ -322,7 +322,7 @@ build_ievm() {
     fi
 
     log "Checking for existing ${vm} VM"
-    if ! VBoxManage showvminfo "${vm}" >/dev/null 2>/dev/null
+    if ! `VBoxManage list vms` == *"${vm}"*
     then
         local disk_path="${ievms_home}/${vm}-disk1.vmdk"
         log "Creating ${vm} VM (disk: ${disk_path})"


### PR DESCRIPTION
I found that `VBoxManage showvminfo ${vm} >/dev/null 2>/dev/null` returned blank if the VM exists or not. Causing the creation of the VM to fail. 

Checking if the VM exists within the available list seem's to be an ideal solution.

```
VBoxManage list hostinfo
Host Information:

Host time: 2013-07-21T15:08:05.366000000Z
Processor online count: 2
Processor count: 2
Processor#0 speed: 2594 MHz
Processor#0 description:         Intel(R) Celeron(R) CPU G1610 @ 2.60GHz
Processor#1 speed: 2594 MHz
Processor#1 description:         Intel(R) Celeron(R) CPU G1610 @ 2.60GHz
Memory size: 3661 MByte
Memory available: 1711 MByte
Operating system: Linux
Operating system version: Ubuntu 12.04.2 LTS (GNU/Linux 3.5.0-36-generic x86_64)
```
