### PR TITLE
Tune video ram to 32MB and enable hostiocache also for SATA controller

### DIFF
--- a/ievms.sh
+++ b/ievms.sh
@@ -328,6 +328,9 @@ build_ievm() {
         local disk_path="${ievms_home}/${vm}-disk1.vmdk"
         log "Creating ${vm} VM (disk: ${disk_path})"
         VBoxManage import "${ova}" --vsys 0 --vmname "${vm}" --unit "${unit}" --disk "${disk_path}"
+        
+        log "Modifying ${vm} VRAM size to 32MB"
+        VBoxManage modifyvm "${vm}" --vram 32
 
         log "Building ${vm} VM"
         declare -F "build_ievm_ie${1}" && "build_ievm_ie${1}"

--- a/ievms.sh
+++ b/ievms.sh
@@ -331,6 +331,10 @@ build_ievm() {
         
         log "Modifying ${vm} VRAM size to 32MB"
         VBoxManage modifyvm "${vm}" --vram 32
+        
+        log "Enable hostiocache for IDE & SATA controllers in ${vm} VM" 
+        VBoxManage storagectl "${vm}" --name "IDE Controller" --hostiocache on 2> /dev/null || true
+        VBoxManage storagectl "${vm}" --name "SATA Controller" --hostiocache on 2> /dev/null || true
 
         log "Building ${vm} VM"
         declare -F "build_ievm_ie${1}" && "build_ievm_ie${1}"


### PR DESCRIPTION
The VMs complain about non-optimal setting in VirtualBox about insufficient video ram for fullscreen mode. This PR changes VRAM size to 32MB for all VMs.
This also enables hostiocache for the SATA controller. It's off by default for SATA controller, but enabled by default for IDE controller. This change enables it for both IO controllers.
