### PR TITLE
196 display memory (vram) set too low to function

### DIFF
--- a/ievms.sh
+++ b/ievms.sh
@@ -358,6 +358,13 @@ build_ievm() {
         log "Creating ${vm} VM (disk: ${disk_path})"
         VBoxManage import "${ova}" --vsys 0 --vmname "${vm}" --unit "${unit}" --disk "${disk_path}"
 
+        log "Ensuring video memory (vram) at minimum of 64MB"
+        local current_vram=$(VBoxManage showvminfo "${vm}" --machinereadable | grep ^vram= | sed -e 's/vram=//')
+        if [ "$current_vram" -lt 64 ]
+        then
+            VBoxManage modifyvm "${vm}" --vram 64
+        fi
+
         log "Building ${vm} VM"
         declare -F "build_ievm_ie${1}" && "build_ievm_ie${1}"
 


### PR DESCRIPTION
```
Detect the display memory setting, and increase it if less than 64MB.

On certain VirtualBox setups, the default display memory setting for
newly imported boxes is 16MB, lower than the minimum 18MB suggested by
VirtualBox's own graphical UI. This can cause boxes to hang on boot,
preventing ievms.sh from configuring them and even hanging the host.
```
