### PR TITLE
added an option to disable hardware virtualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ To specify where the VMs are installed, use the `INSTALL_PATH` variable:
     curl -s https://raw.githubusercontent.com/xdissent/ievms/master/ievms.sh | env INSTALL_PATH="/Path/to/.ievms" bash
 
 
+Disabling hardware virtualization
+---------------------------------
+
+By default VirtualBox enables hardware virtualization (VT-x or AMD-V). If hardware virtualization is not available (e.g. it's disabled in the BIOS), virtual machines will not start. To force software virtualization, set the `DISABLE_HWV` variable:
+
+    curl -s https://raw.githubusercontent.com/xdissent/ievms/master/ievms.sh | env DISABLE_HWV="yes" bash
+
+
 Passing additional options to curl
 ----------------------------------
 

--- a/ievms.sh
+++ b/ievms.sh
@@ -14,6 +14,9 @@ ievms_version="0.2.1"
 # Options passed to each `curl` command.
 curl_opts=${CURL_OPTS:-""}
 
+# Disable hardware virtualization
+disable_hwv=${DISABLE_HWV:-"no"}
+
 # Reuse XP virtual machines for IE versions that are supported.
 reuse_xp=${REUSE_XP:-"yes"}
 
@@ -403,6 +406,10 @@ build_ievm() {
         local disk_path="${ievms_home}/${vm}-disk1.vmdk"
         log "Creating ${vm} VM (disk: ${disk_path})"
         VBoxManage import "${ova}" --vsys 0 --vmname "${vm}" --unit "${unit}" --disk "${disk_path}"
+        if [ "${disable_hwv}" != "no" ]
+        then
+            VBoxManage modifyvm "${vm}" --cpus 1 --hwvirtex off
+        fi
 
         log "Building ${vm} VM"
         declare -F "build_ievm_ie${1}" && "build_ievm_ie${1}"


### PR DESCRIPTION
If hardware virtualization is not available, ievms cannot start a virtual machine created with the default settings. This adds an option to disable hardware virtualization.