### PR TITLE
Update MD5_check to print output before it runs the MD5 command

### DIFF
--- a/ievms.sh
+++ b/ievms.sh
@@ -43,6 +43,8 @@ fail() { log "\nERROR: $*\n" ; exit 1 ; }
 check_md5() {
     local md5
 
+    log "Running MD5 check for ${1}"
+
     case $kernel in
         Darwin) md5=`md5 "${1}" | rev | cut -c-32 | rev` ;;
         Linux) md5=`md5sum "${1}" | cut -c-32` ;;


### PR DESCRIPTION
The console appears unresponsive between when the download ends and when the MD5 check finishes, so printing some output before it runs will at least show the user that the MD5 is running in the background