### PR TITLE
Fix download of EDGE browser

### DIFF
--- a/ievms.sh
+++ b/ievms.sh
@@ -387,7 +387,7 @@ build_ievm() {
     local url
     if [ "${os}" == "Win10" ]
     then
-        url="https://az792536.vo.msecnd.net/vms/VMBuild_20150801/VirtualBox/MSEdge/Mac/Microsoft%20Edge.Win10.For.Mac.VirtualBox.zip"
+        url="https://az792536.vo.msecnd.net/vms/VMBuild_20150801/VirtualBox/MSEdge/Windows/Microsoft%20Edge.Win10.For.Windows.VirtualBox.zip"
     else
         url="http://virtualization.modern.ie/vhd/IEKitV1_Final/VirtualBox/OSX/${archive}"
     fi
@@ -399,7 +399,7 @@ build_ievm() {
         IE8_Win7.zip) md5="21b0aad3d66dac7f88635aa2318a3a55" ;;
         IE9_Win7.zip) md5="58d201fe7dc7e890ad645412264f2a2c" ;;
         IE10_Win8.zip) md5="cc4e2f4b195e1b1e24e2ce6c7a6f149c" ;;
-        MSEdge_Win10.zip) md5="c1011b491d49539975fb4c3eeff16dae" ;;
+        MSEdge_Win10.zip) md5="2a591bd4e59c8fc1ca9818c31b99666b" ;;
     esac
     
     log "Checking for existing OVA at ${ievms_home}/${ova}"


### PR DESCRIPTION
The old "Mac-Version" is no longer available. The Microsoft site now links to the "Windows"-ZIP even when Mac is selected.

# TODO:
- [ ] after extraction .ova file has wrong name and script does not continue. file needs to be renamed from `IE11 - Win10.ova` to `MSEdge - Win10.ova`

I did not know where to do the renaming.