### PR TITLE
Fixes URL for unar

### DIFF
--- a/ievms.sh
+++ b/ievms.sh
@@ -163,10 +163,10 @@ check_ext_pack() {
 
 # Download and install `unar` from Google Code.
 install_unar() {
-    local url="http://theunarchiver.googlecode.com/files/unar1.5.zip"
+    local url="http://wakaba.c3.cx/releases/TheUnarchiver/unar1.10.1.zip"
     local archive=`basename "${url}"`
 
-    download "unar" "${url}" "${archive}" "fbf544d1332c481d7d0f4e3433fbe53b"
+    download "unar" "${url}" "${archive}" "d548661e4b6c33512074df81e39ed874"
 
     unzip "${archive}" || fail "Failed to extract ${ievms_home}/${archive} to ${ievms_home}/, unzip command returned error code $?"
 


### PR DESCRIPTION
As Google Code's URL for unar returns a 404 status code, this commit updates the download address to http://wakaba.c3.cx/releases/TheUnarchiver/unar1.10.1.zip (see https://github.com/xdissent/ievms/issues/236#issuecomment-242939186).

This is a very old version of the software (current version is 3.11.1, so perhaps this should be updated too.

Note: I was able to install unar using homebrew so maybe we should check for 'brew' and install from there.
