### PR TITLE
Ievms from microsoft cdn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ CHANGELOG
 * Updates Windows VM MD5
 * Adds WinXP Mode documentation for Win7
 * Updates the URL and MD5 for The Unarchiver file
-* Fixes BVoxManage import not mounting disk drive
+* Fixes VBoxManage import not mounting disk drive
 
 ## v0.3.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ CHANGELOG
 
 * Add CHANGELOG with last 2 releases
 * Drops support for WinXP, WinVista, IE6 & IE7
+* Updates VM download source to get latest builds
+* Updates Windows VM MD5
+* Adds WinXP Mode documentation for Win7
+* Updates the URL and MD5 for The Unarchiver file
 
 ## v0.3.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+CHANGELOG
+---
+
+## unreleased
+
+* Add CHANGELOG with last 2 releases
+* Drops support for WinXP, WinVista, IE6 & IE7
+
+## v0.3.3
+
+* https://github.com/xdissent/ievms/compare/v0.3.2...v0.3.3
+
+## v0.3.2
+
+* https://github.com/xdissent/ievms/compare/v0.3.1...v0.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
 * Updates Windows VM MD5
 * Adds WinXP Mode documentation for Win7
 * Updates the URL and MD5 for The Unarchiver file
+* Fixes BVoxManage import not mounting disk drive
 
 ## v0.3.3
 

--- a/README.md
+++ b/README.md
@@ -169,20 +169,11 @@ command used will automatically attempt to resume where it left off.~~
 Unfortunately, the modern.IE download servers do not support resume.
 
 
-Reusing XP VMs
---------------
+Using Win7 with XP Mode
+-----------------------
 
-IE7 and IE8 ship from MS on Vista and Win7 respectively. Both of these
-images are far larger than the IE6 XP image, which also technically supports
-IE7 and IE8. To save bandwidth, space and time, ievms will reuse
-(duplicate) the IE6 XP VM image for both. Virtualbox guest control is used
-to run the appropriate IE installer within the VM. The `clean` snapshot
-includes the updated browser version.
-
-**NOTE:** If you'd like to disable XP VM reuse for IE7 and IE8, set the
-environment variable `REUSE_XP` to anything other than `yes`:
-
-    curl -s https://raw.githubusercontent.com/xdissent/ievms/master/ievms.sh | env REUSE_XP="no" bash
+You can download a copy of Windows XP Mode to run on a Windows 7 machine
+through https://www.microsoft.com/en-us/download/details.aspx?id=8002
 
 
 Reusing Win7 VMs

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ Installation
 
    * To install IE versions 8, 9, 10, 11 and EDGE use:
 
-        curl -s https://raw.githubusercontent.com/xdissent/ievms/master/ievms.sh | bash
+        `curl -s https://raw.githubusercontent.com/xdissent/ievms/master/ievms.sh | bash`
 
    * To install specific IE versions (IE7, IE9 and EDGE only for example) use:
 
-        curl -s https://raw.githubusercontent.com/xdissent/ievms/master/ievms.sh | env IEVMS_VERSIONS="7 9 EDGE" bash
+        `curl -s https://raw.githubusercontent.com/xdissent/ievms/master/ievms.sh | env IEVMS_VERSIONS="7 9 EDGE" bash`
 
 **3.)** Launch Virtual Box.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 Overview
 ========
 
-Microsoft provides virtual machine disk images to facilitate website testing 
-in multiple versions of IE, regardless of the host operating system. 
-With a single command, you can have IE6, IE7, IE8,
-IE9, IE10, IE11 and MSEdge running in separate virtual machines.
+Microsoft provides virtual machine disk images to facilitate website testing
+in multiple versions of IE, regardless of the host operating system.
+With a single command, you can have IE8, IE9, IE10, IE11
+and MSEdge running in separate virtual machines.
 
 [![Click here to lend your support to ievms and make a donation at pledgie.com!](http://pledgie.com/campaigns/15995.png?skin_name=chrome)](http://pledgie.com/campaigns/15995)
 
@@ -12,7 +12,7 @@ IE9, IE10, IE11 and MSEdge running in separate virtual machines.
 Quickstart
 ==========
 
-Just paste this into a terminal: 
+Just paste this into a terminal:
 
     curl -s https://raw.githubusercontent.com/xdissent/ievms/master/ievms.sh | bash
 
@@ -35,7 +35,7 @@ Installation
 
 **2.)** Download and unpack ievms:
 
-   * To install IE versions 6, 7, 8, 9, 10, 11 and EDGE use:
+   * To install IE versions 8, 9, 10, 11 and EDGE use:
 
         curl -s https://raw.githubusercontent.com/xdissent/ievms/master/ievms.sh | bash
 
@@ -47,9 +47,9 @@ Installation
 
 **4.)** Choose ievms image from Virtual Box.
 
-The OVA images are massive and can take hours or tens of minutes to 
+The OVA images are massive and can take hours or tens of minutes to
 download, depending on the speed of your internet connection. You might want
-to start the install and then go catch a movie, or maybe dinner, or both. 
+to start the install and then go catch a movie, or maybe dinner, or both.
 
 
 Recovering from a failed installation
@@ -73,7 +73,7 @@ To specify where the VMs are installed, use the `INSTALL_PATH` variable:
 Passing additional options to curl
 ----------------------------------
 
-The `curl` command is passed any options present in the `CURL_OPTS` 
+The `curl` command is passed any options present in the `CURL_OPTS`
 environment variable. For example, you can set a download speed limit:
 
     curl -s https://raw.githubusercontent.com/xdissent/ievms/master/ievms.sh | env CURL_OPTS="--limit-rate 50k" bash
@@ -107,7 +107,7 @@ A full ievms install will require approximately 69G:
     4.5M    unar
     4.1M    unar1.5.zip
      69G    total
-   
+
 You may remove all files except `*.vmdk` after installation and they will be
 re-downloaded if ievms is run again in the future:
 
@@ -135,7 +135,7 @@ A full installation will download roughly 12.5G of data.
 amount of space and bandwidth. If it is disabled (`REUSE_XP=no`) the disk space
 required climbs to 95G (49G if cleaned post-install) and around 22G will be
 downloaded. Reusing the Win7 VM on the other hand (also the default), saves
-tons of bandwidth but pretty much breaks even on disk space. Disable it with 
+tons of bandwidth but pretty much breaks even on disk space. Disable it with
 `REUSE_WIN7=no`.
 
 
@@ -147,7 +147,7 @@ Clean Snapshot
 --------------
 
 A snapshot is automatically taken upon install, allowing rollback to the
-pristine virtual environment configuration. Anything can go wrong in 
+pristine virtual environment configuration. Anything can go wrong in
 Windows and rather than having to worry about maintaining a stable VM,
 you can simply revert to the `clean` snapshot to reset your VM to the
 initial state.
@@ -164,7 +164,7 @@ guest control from the host machine.
 Resuming Downloads
 ------------------
 
-~~If one of the comically large files fails to download, the `curl` 
+~~If one of the comically large files fails to download, the `curl`
 command used will automatically attempt to resume where it left off.~~
 Unfortunately, the modern.IE download servers do not support resume.
 
@@ -179,7 +179,7 @@ IE7 and IE8. To save bandwidth, space and time, ievms will reuse
 to run the appropriate IE installer within the VM. The `clean` snapshot
 includes the updated browser version.
 
-**NOTE:** If you'd like to disable XP VM reuse for IE7 and IE8, set the 
+**NOTE:** If you'd like to disable XP VM reuse for IE7 and IE8, set the
 environment variable `REUSE_XP` to anything other than `yes`:
 
     curl -s https://raw.githubusercontent.com/xdissent/ievms/master/ievms.sh | env REUSE_XP="no" bash
@@ -188,14 +188,14 @@ environment variable `REUSE_XP` to anything other than `yes`:
 Reusing Win7 VMs
 ----------------
 
-Currently there exists a [bug](https://www.virtualbox.org/ticket/11134) in 
+Currently there exists a [bug](https://www.virtualbox.org/ticket/11134) in
 VirtualBox (or possibly elsewhere) that disables guest control after a Windows 8
 virtual machine's state is saved. To better support guest control and to
 eliminate yet another image download, ievms will re-use the IE9 Win7 image for
 IE10 and IE11 by default. In addition, the Win7 VMs are the only ones which can
 be successfully "rearmed" to extend the activation period.
 
-**NOTE:** If you'd like to disable Win7 VM reuse for IE10, set the environment 
+**NOTE:** If you'd like to disable Win7 VM reuse for IE10, set the environment
 variable `REUSE_WIN7` to anything other than `yes`:
 
     curl -s https://raw.githubusercontent.com/xdissent/ievms/master/ievms.sh | REUSE_WIN7="no" bash
@@ -219,8 +219,8 @@ script may then use Virtualbox guest controls to manage the VM.
 
 The control ISO is built within a [Vagrant](http://vagrantup.com) Ubuntu VM.
 If you'd like to build it yourself, clone the ievms repository, install
-Vagrant and run `vagrant up`. The base ntpasswd boot disk will be downloaded, 
-unpacked and customized within the Vagrant VM. A custom linux kernel is 
+Vagrant and run `vagrant up`. The base ntpasswd boot disk will be downloaded,
+unpacked and customized within the Vagrant VM. A custom linux kernel is
 cross-compiled for the image as well.
 
 

--- a/ievms.sh
+++ b/ievms.sh
@@ -215,14 +215,14 @@ find_iso() {
 attach() {
     log "Attaching ${3}"
     VBoxManage storageattach "${1}" --storagectl "IDE Controller" --port 0 \
-        --device 0 --type dvddrive --medium "${2}"
+        --device 1 --type dvddrive --medium "${2}"
 }
 
 # Eject the dvd image from the virtual machine.
 eject() {
     log "Ejecting ${2}"
     VBoxManage storageattach "${1}" --storagectl "IDE Controller" --port 0 \
-        --device 0 --type dvddrive --medium "none" --forceunmount
+        --device 1 --type dvddrive --medium "emptydrive"
 }
 
 # Boot the virtual machine with the control ISO in the dvd drive then wait for

--- a/ievms.sh
+++ b/ievms.sh
@@ -334,7 +334,7 @@ build_ievm() {
     local build_timestamp
     if [ "${os}" == "Win10" ]
     then
-        build_timestamp="20180425"
+        build_timestamp="20190311"
     elif [ "${os}" == "Win81" ]
     then
         build_timestamp="20180102"
@@ -350,7 +350,7 @@ build_ievm() {
         IE10_Win7.zip)    md5="21d0dee59fd11bdfce237864ef79063b" ;;
         IE11_Win7.zip)    md5="24675c913c4a74c87dc11f8ccb6c8f9e" ;;
         IE11_Win81.zip)   md5="896db7a54336982241d25f704f35d6c2" ;;
-        MSEdge_Win10.zip) md5="fdbcfb79d36c6ffd424c9d36a88ddc02" ;;
+        MSEdge_Win10.zip) md5="b31441edbb30d6bc7df3202269c25cfd" ;;
     esac
 
     log "Checking for existing OVA at ${ievms_home}/${ova}"

--- a/ievms.sh
+++ b/ievms.sh
@@ -160,10 +160,10 @@ check_ext_pack() {
 
 # Download and install `unar` from https://theunarchiver.com/ CDN
 install_unar() {
-    local url="https://dl.devmate.com/com.macpaw.site.theunarchiver/TheUnarchiver.zip"
+    local url="https://cdn.theunarchiver.com/downloads/unarMac.zip"
     local archive=`basename "${url}"`
 
-    download "unar" "${url}" "${archive}" "606f5f186d6d0661fc5558b628fb3b51"
+    download "unar" "${url}" "${archive}" "91796924b1b21ee586ed904b319bb447"
 
     unzip "${archive}" || fail "Failed to extract ${ievms_home}/${archive} to ${ievms_home}/, unzip command returned error code $?"
 

--- a/ievms.sh
+++ b/ievms.sh
@@ -14,9 +14,6 @@ ievms_version="0.4.0"
 # Options passed to each `curl` command.
 curl_opts=${CURL_OPTS:-""}
 
-# Reuse XP virtual machines for IE versions that are supported.
-reuse_xp=${REUSE_XP:-"yes"}
-
 # Reuse Win7 virtual machines for IE versions that are supported.
 reuse_win7=${REUSE_WIN7:-"yes"}
 
@@ -161,12 +158,12 @@ check_ext_pack() {
     fi
 }
 
-# Download and install `unar` from Google Code.
+# Download and install `unar` from https://theunarchiver.com/ CDN
 install_unar() {
-    local url="http://unarchiver.c3.cx/downloads/unar1.10.1.zip"
+    local url="https://dl.devmate.com/com.macpaw.site.theunarchiver/TheUnarchiver.zip"
     local archive=`basename "${url}"`
 
-    download "unar" "${url}" "${archive}" "d548661e4b6c33512074df81e39ed874"
+    download "unar" "${url}" "${archive}" "606f5f186d6d0661fc5558b628fb3b51"
 
     unzip "${archive}" || fail "Failed to extract ${ievms_home}/${archive} to ${ievms_home}/, unzip command returned error code $?"
 
@@ -391,14 +388,13 @@ build_ievm() {
     local url="https://az792536.vo.msecnd.net/vms/VMBuild_${build_timestamp}/VirtualBox/${browser}/${browser}.${os}.VirtualBox.zip"
 
     local md5
-    # TODO: get md5 of missing archives once downloaded
     case $archive in
-        IE8_Win7.zip) md5="" ;;
-        IE9_Win7.zip) md5="0e1d3669b426fce8b0d772665f113302" ;;
-        IE10_Win7.zip) md5="21d0dee59fd11bdfce237864ef79063b" ;;
-        IE11_Win7.zip) md5="" ;;
-        IE11_Win81.zip) md5="" ;;
-        MSEdge_Win10.zip) md5="" ;;
+        IE8_Win7.zip)     md5="342e3d2d163f3ce345cfaa9cb5fa8012" ;;
+        IE9_Win7.zip)     md5="0e1d3669b426fce8b0d772665f113302" ;;
+        IE10_Win7.zip)    md5="21d0dee59fd11bdfce237864ef79063b" ;;
+        IE11_Win7.zip)    md5="24675c913c4a74c87dc11f8ccb6c8f9e" ;;
+        IE11_Win81.zip)   md5="896db7a54336982241d25f704f35d6c2" ;;
+        MSEdge_Win10.zip) md5="fdbcfb79d36c6ffd424c9d36a88ddc02" ;;
     esac
 
     log "Checking for existing OVA at ${ievms_home}/${ova}"
@@ -432,7 +428,7 @@ build_ievm() {
     fi
 }
 
-# Build the IE8 virtual machine, reusing the XP VM if requested (the default).
+# Build the IE8 virtual machine.
 build_ievm_ie8() {
     boot_auto_ga "IE8 - Win7"
 }
@@ -442,13 +438,13 @@ build_ievm_ie9() {
     boot_auto_ga "IE9 - Win7"
 }
 
-# Build the IE10 virtual machine, reusing the Win7 VM if requested (the default).
+# Build the IE10 virtual machine.
 build_ievm_ie10() {
     boot_auto_ga "IE10 - Win7"
     install_ie_win7 "IE10 - Win7" "https://raw.githubusercontent.com/kbandla/installers/master/MSIE/IE10-Windows6.1-x86-en-us.exe" "0f14b2de0b3cef611b9c1424049e996b"
 }
 
-# Build the IE11 virtual machine, reusing the Win7 VM always.
+# Build the IE11 virtual machine, reusing the Win7 VM if requested (the default).
 build_ievm_ie11() {
     if [ "${reuse_win7}" != "yes" ]
     then

--- a/ievms.sh
+++ b/ievms.sh
@@ -9,7 +9,7 @@ set -o pipefail
 # ## Global Variables
 
 # The ievms version.
-ievms_version="0.4.0"
+ievms_version="0.3.3"
 
 # Options passed to each `curl` command.
 curl_opts=${CURL_OPTS:-""}

--- a/ievms.sh
+++ b/ievms.sh
@@ -214,14 +214,15 @@ find_iso() {
 # Attach a dvd image to the virtual machine.
 attach() {
     log "Attaching ${3}"
-    VBoxManage storageattach "${1}" --storagectl "IDE Controller" --port 1 \
+    VBoxManage storageattach "${1}" --storagectl "IDE Controller" --port 0 \
         --device 0 --type dvddrive --medium "${2}"
 }
 
 # Eject the dvd image from the virtual machine.
 eject() {
     log "Ejecting ${2}"
-    VBoxManage modifyvm "${1}" --dvd none
+    VBoxManage storageattach "${1}" --storagectl "IDE Controller" --port 0 \
+        --device 0 --type dvddrive --medium "none" --forceunmount
 }
 
 # Boot the virtual machine with the control ISO in the dvd drive then wait for
@@ -318,7 +319,7 @@ build_ievm() {
             prefix="MS"
             version="Edge"
             os="Win10"
-            unit="8"
+            unit="10"
             ;;
         *) fail "Invalid IE version: ${1}" ;;
     esac
@@ -366,7 +367,8 @@ build_ievm() {
     then
         local disk_path="${ievms_home}/${vm}-disk1.vmdk"
         log "Creating ${vm} VM (disk: ${disk_path})"
-        VBoxManage import "${ova}" --vsys 0 --vmname "${vm}" --unit "${unit}" --disk "${disk_path}"
+        VBoxManage import "${ova}" --vsys 0 --vmname "${vm}" \
+            --unit "${unit}" --disk "${disk_path}"
 
         log "Adding shared folder"
         VBoxManage sharedfolder add "${vm}" --automount --name ievms \


### PR DESCRIPTION
Hello,

I don't expect this to get merged but I wanted to fix the lingering issues with `ievms.sh` that I have been manually patching as I need and I figured it would be beneficial to others. I wanted to bump version to `0.4.0` but I realized that there's a dependency on the releases for `ievms-control-0.3.3.iso` that I have no control over.

I removed WinXP VMs from the downloader, however I added a link in README for a Windows XP mode for Windows 7 machines which should prove helpful. This is working with VBoxManage version 5.2.12r122591